### PR TITLE
fix: resolve modules correctly by metro

### DIFF
--- a/apps/sample-app/babel.config.js
+++ b/apps/sample-app/babel.config.js
@@ -1,19 +1,3 @@
-const path = require('path');
-const fs = require('fs');
-const root = path.resolve(__dirname, '../..');
-
-const alias = {};
-
-const packagesPath = path.join(root, 'packages');
-
-for (const file of fs.readdirSync(packagesPath)) {
-  const packageDirPath = path.join(packagesPath, file);
-  const packageJsonPath = path.join(packageDirPath, 'package.json');
-  const pak = require(packageJsonPath);
-
-  alias[pak.name] = path.join(packageDirPath, pak.source);
-}
-
 module.exports = {
   presets: ['module:@react-native/babel-preset'],
   plugins: [
@@ -22,7 +6,6 @@ module.exports = {
       {
         extensions: ['.tsx', '.ts', '.js', '.json'],
         alias: {
-          ...alias,
           '@/components': './src/components',
           '@/constants': './src/constants',
           '@/contexts': './src/contexts',

--- a/apps/sample-app/metro.config.js
+++ b/apps/sample-app/metro.config.js
@@ -1,7 +1,50 @@
 const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
+const exclusionList = require('metro-config/src/defaults/exclusionList');
 const path = require('path');
+const fs = require('fs');
+const escape = require('escape-string-regexp');
 
 const root = path.resolve(__dirname, '../..');
+const projectRoot = __dirname;
+const packagesPath = path.join(root, 'packages');
+
+const packageNames = fs.readdirSync(packagesPath);
+
+const packages = packageNames.map((packageName) => {
+  const packagePath = path.join(packagesPath, packageName);
+  const pkgPath = path.join(packagePath, 'package.json');
+
+  const pkg = require(pkgPath);
+
+  return {
+    name: pkg.name,
+    path: packagePath,
+    peerDependencies: Object.keys(pkg.peerDependencies),
+  };
+});
+
+const exclusionPatterns = packages.flatMap((pkg) =>
+  pkg.peerDependencies.map(
+    (peerDependency) =>
+      new RegExp(
+        `^${escape(path.join(pkg.path, 'node_modules', peerDependency))}\\/.*$`
+      )
+  )
+);
+
+const watchFolders = [projectRoot, ...packages.map((pkg) => pkg.path)];
+
+const nodeModulesPaths = watchFolders.map((folder) =>
+  path.resolve(folder, 'node_modules')
+);
+
+const extraNodeModules = packages.reduce((acc, pkg) => {
+  const sourcePath = path.join(pkg.path, 'src');
+
+  acc[pkg.name] = sourcePath;
+
+  return acc;
+}, {});
 
 /**
  * Metro configuration
@@ -10,7 +53,13 @@ const root = path.resolve(__dirname, '../..');
  * @type {import('metro-config').MetroConfig}
  */
 const config = {
-  watchFolders: [root],
+  watchFolders,
+
+  resolver: {
+    blockList: exclusionList(exclusionPatterns),
+    nodeModulesPaths,
+    extraNodeModules,
+  },
 
   transformer: {
     getTransformOptions: async () => ({


### PR DESCRIPTION
## Summary

This addresses an issue where Metro was incorrectly resolving `@openmobilehub/storage-googledrive`'s `peerDependencies` modules within the package's directory instead of the sample app directory. As a result, `NativeEventEmitter` was unable to emit events from `react-native-file-access` to the sample app.

This fix ensures that Metro [resolves](https://metrobundler.dev/docs/resolution#algorithm) all packages's `peerDependencies` from the `apps/sample-app` directory, thus restoring proper event emission to the sample app.