### PR TITLE
refactor: permissions docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ This is the main directory of the mono-repo for React Native OMH Storage. If you
 
 <summary>Show details</summary>
 
-[`Permission`](https://ideal-doodle-m69lynw.pages.github.io/docs/api/core/src/classes/Permission#properties)
+[`Permission#properties`](https://ideal-doodle-m69lynw.pages.github.io/docs/api/core/src/classes/Permission#properties)
 
 | Property    | Google Drive (GMS) | Google Drive (non-GMS) | OneDrive | Dropbox |
 | ----------- | :----------------: | :--------------------: | :------: | :-----: |
@@ -117,7 +117,7 @@ This is the main directory of the mono-repo for React Native OMH Storage. If you
 
 > **Dropbox**: The `id` corresponds to the underlying identity ID.
 
-[`Permission`](https://ideal-doodle-m69lynw.pages.github.io/docs/api/core/src/classes/Permission#extended-by)
+[`Permission#extended-by`](https://ideal-doodle-m69lynw.pages.github.io/docs/api/core/src/classes/Permission#extended-by)
 
 | Type        | Google Drive (GMS) | Google Drive (non-GMS) | OneDrive | Dropbox |
 | ----------- | :----------------: | :--------------------: | :------: | :-----: |
@@ -170,14 +170,14 @@ This is the main directory of the mono-repo for React Native OMH Storage. If you
 
 | Type         | Google Drive (GMS) | Google Drive (non-GMS) | OneDrive | Dropbox |
 | ------------ | :----------------: | :--------------------: | :------: | :-----: |
-| User         |         ✅         |           ✅           |    ✅    |   ✅    |
-| Group        |         ✅         |           ✅           |    ✅    |   ❌    |
-| Domain       |         ✅         |           ✅           |    ❌    |   ❌    |
-| Anyone       |         ✅         |           ✅           |    ❌    |   ❌    |
-| WithObjectId |         ❌         |           ❌           |    ✅    |   ✅    |
-| WithAlias    |         ❌         |           ❌           |    ✅    |   ❌    |
+| user         |         ✅         |           ✅           |    ✅    |   ✅    |
+| group        |         ✅         |           ✅           |    ✅    |   ❌    |
+| domain       |         ✅         |           ✅           |    ❌    |   ❌    |
+| anyone       |         ✅         |           ✅           |    ❌    |   ❌    |
+| objectId     |         ❌         |           ❌           |    ✅    |   ✅    |
+| alias        |         ❌         |           ❌           |    ✅    |   ❌    |
 
-> **Dropbox**: To invite a group, use `WithObjectId` and provide the group ID.
+> **Dropbox**: To invite a group, use `objectId` and provide the group ID.
 
 </details>
 


### PR DESCRIPTION
## Summary
@andrei-zgirvaci In the end, there was a little to change; you did a great job with the permissions docs. I misread the purpose of the `Permission#properties` and `Permission#extended-by` tables - hence, I updated their titles, but I am open to changing the naming format. I also added cosmetic changes regarding the naming of the `PermissionRecipient` type to resemble the representation in the code.