### PR TITLE
fix/OMHD-550&553: OneDrive upload fixes

### DIFF
--- a/packages/onedrive/README.md
+++ b/packages/onedrive/README.md
@@ -85,6 +85,8 @@ Interacting with the OneDrive storage provider follows the same pattern as other
 
 When updating a file, if the new file has a different name than the updated file, two additional versions might sometimes appear in the system. One version comes from updating the content of the file, and the other comes from updating the file name.
 
+When updating a file created by the createFileWithExtension method, no new version appears immediately after the first update. However, once the file has been updated, subsequent updates will generate new versions.
+
 The [Sharing Links](https://learn.microsoft.com/en-us/graph/api/resources/permission?view=graph-rest-1.0#sharing-links) permissions are not supported.
 
 The [search](https://learn.microsoft.com/en-us/graph/api/driveitem-search?view=graph-rest-1.0&tabs=java) query takes several fields including filename, metadata, and file content when searching.

--- a/packages/onedrive/src/OneDriveStorageRepository.ts
+++ b/packages/onedrive/src/OneDriveStorageRepository.ts
@@ -19,6 +19,7 @@ import type { DriveItem } from './data/response/DriveItem';
 import type { OneDriveStorageApiService } from './OneDriveStorageApiService';
 
 const PRECONDITION_ERROR_STATUS_CODE = 412;
+const CONFLICT_ERROR_STATUS_CODE = 409;
 
 export class OneDriveStorageRepository {
   private apiService: OneDriveStorageApiService;
@@ -143,7 +144,8 @@ export class OneDriveStorageRepository {
       // uploading a new file version and renaming the file at the same time.
       if (
         error instanceof ApiException &&
-        error.code === PRECONDITION_ERROR_STATUS_CODE &&
+        (error.code === PRECONDITION_ERROR_STATUS_CODE ||
+          error.code === CONFLICT_ERROR_STATUS_CODE) &&
         retry
       ) {
         return this.renameFile(fileId, fileName, false);


### PR DESCRIPTION
## Summary

Issue https://callstackio.atlassian.net/browse/OMHD-550 is not fixable - added additional paragraph in the caveats section.

## Demo
_Read from bottom to top:_

<img width="1417" alt="image" src="https://github.com/user-attachments/assets/4afda5dd-77db-4567-926d-22677c265941">

- [x] Documentation is up to date to reflect these changes

Closes: [OMHD-550](https://callstackio.atlassian.net/browse/OMHD-550)
Closes: [OMHD-553](https://callstackio.atlassian.net/browse/OMHD-553)
