### PR TITLE
OMHD-532 Dark mode support

### DIFF
--- a/apps/sample-app/App.tsx
+++ b/apps/sample-app/App.tsx
@@ -8,6 +8,7 @@ import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import { ContextsProvider } from '@/contexts/provider/ContextsProvider';
 import { QueryClientProvider } from '@/data/client/QueryClientProvider';
+import useCreateAdaptiveTheme from '@/hooks/useCreateAdaptiveTheme.ts';
 import { RootNavigationContainer } from '@/navigation/RootNavigationContainer';
 
 import { styles } from './App.styles';
@@ -21,10 +22,12 @@ interface ProvidersProps {
 }
 
 const Providers = ({ children }: ProvidersProps) => {
+  const theme = useCreateAdaptiveTheme();
+
   return (
     <RootSiblingParent>
       <GestureHandlerRootView style={styles.gestureHanlderContainer}>
-        <PaperProvider>
+        <PaperProvider theme={theme}>
           <BottomSheetModalProvider>{children}</BottomSheetModalProvider>
         </PaperProvider>
       </GestureHandlerRootView>

--- a/apps/sample-app/android/app/src/main/res/values/colors.xml
+++ b/apps/sample-app/android/app/src/main/res/values/colors.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+/*
+ * Copyright 2023 Open Mobile Hub
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+
+<resources>
+    <color name="purple_200">#FFBB86FC</color>
+    <color name="purple_700">#FF3700B3</color>
+    <color name="teal_200">#FF03DAC5</color>
+    <color name="black">#FF000000</color>
+    <color name="white">#FFFFFFFF</color>
+</resources>

--- a/apps/sample-app/android/app/src/main/res/values/styles.xml
+++ b/apps/sample-app/android/app/src/main/res/values/styles.xml
@@ -1,9 +1,17 @@
 <resources>
 
-    <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
-        <!-- Customize your theme here. -->
-        <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
-    </style>
+  <!-- Base application theme. -->
+  <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
+    <!-- Primary brand color. -->
+    <item name="colorPrimary">@color/purple_200</item>
+    <item name="colorPrimaryVariant">@color/purple_700</item>
+    <item name="colorOnPrimary">@color/white</item>
+    <!-- Secondary brand color. -->
+    <item name="colorSecondary">@color/teal_200</item>
+    <item name="colorSecondaryVariant">@color/teal_200</item>
+    <item name="colorOnSecondary">@color/black</item>
+    <!-- Status bar color. -->
+    <item name="android:statusBarColor">?attr/colorPrimary</item>
+  </style>
 
 </resources>

--- a/apps/sample-app/src/components/bottomSheet/BottomSheet.tsx
+++ b/apps/sample-app/src/components/bottomSheet/BottomSheet.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, ReactNode } from 'react';
+import { forwardRef, ReactNode, useMemo } from 'react';
 import { Dimensions, ViewStyle } from 'react-native';
 
 import {
@@ -6,6 +6,8 @@ import {
   BottomSheetModalProps,
   BottomSheetScrollView,
 } from '@gorhom/bottom-sheet';
+
+import useCreateAdaptiveTheme from '@/hooks/useCreateAdaptiveTheme.ts';
 
 import { styles } from './BottomSheet.styles';
 import { BottomSheetBackdrop } from './parts/BottomSheetBackdrop';
@@ -30,6 +32,14 @@ export const BottomSheet = forwardRef<BottomSheetModal, BottomSheetProps>(
     },
     ref
   ) => {
+    const theme = useCreateAdaptiveTheme();
+    const bottomSheetStyle = useMemo(
+      () => ({
+        backgroundColor: theme.colors.background,
+      }),
+      [theme.colors.background]
+    );
+
     return (
       <BottomSheetModal
         {...props}
@@ -42,7 +52,13 @@ export const BottomSheet = forwardRef<BottomSheetModal, BottomSheetProps>(
       >
         <BottomSheetScrollView
           keyboardShouldPersistTaps="handled"
-          style={[styles.contentContainer, contentContainerStyle]}
+          style={[
+            {
+              ...bottomSheetStyle,
+              ...styles.contentContainer,
+            },
+            contentContainerStyle,
+          ]}
         >
           {children}
         </BottomSheetScrollView>

--- a/apps/sample-app/src/components/bottomSheet/BottomSheet.tsx
+++ b/apps/sample-app/src/components/bottomSheet/BottomSheet.tsx
@@ -39,10 +39,18 @@ export const BottomSheet = forwardRef<BottomSheetModal, BottomSheetProps>(
       }),
       [theme.colors.background]
     );
+    const handleIndicatorStyle = useMemo(
+      () => ({
+        backgroundColor: theme.colors.onSurface,
+      }),
+      [theme.colors.onSurface]
+    );
 
     return (
       <BottomSheetModal
         {...props}
+        handleIndicatorStyle={handleIndicatorStyle}
+        handleStyle={bottomSheetStyle}
         ref={ref}
         snapPoints={snapPoints}
         backdropComponent={BottomSheetBackdrop}

--- a/apps/sample-app/src/components/bottomSheetContent/content/update/UpdateContent.tsx
+++ b/apps/sample-app/src/components/bottomSheetContent/content/update/UpdateContent.tsx
@@ -33,7 +33,7 @@ export const UpdateContent = ({ file, closeBottomSheet }: Props) => {
   if (fileUpdateMutation.isPending) {
     return (
       <Portal>
-        <FullScreenLoadingState withBackground />
+        <FullScreenLoadingState overlay />
       </Portal>
     );
   }

--- a/apps/sample-app/src/components/fullScreenLoadingState/FullScreenLoadingState.styles.ts
+++ b/apps/sample-app/src/components/fullScreenLoadingState/FullScreenLoadingState.styles.ts
@@ -6,7 +6,10 @@ export const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
-  background: {
+  backgroundWhite: {
     backgroundColor: 'rgba(255, 255, 255, 0.5)',
+  },
+  backgroundBlack: {
+    backgroundColor: 'rgba(255, 255, 255, 0.1)',
   },
 });

--- a/apps/sample-app/src/components/fullScreenLoadingState/FullScreenLoadingState.tsx
+++ b/apps/sample-app/src/components/fullScreenLoadingState/FullScreenLoadingState.tsx
@@ -2,18 +2,24 @@ import { View, ViewStyle } from 'react-native';
 
 import { ActivityIndicator } from 'react-native-paper';
 
+import useIsDarkTheme from '@/hooks/useIsDarkTheme.ts';
+
 import { styles } from './FullScreenLoadingState.styles';
 
 interface FullScreenLoadingStateProps {
   containerStyles?: ViewStyle;
-  withBackground?: boolean;
+  overlay?: boolean;
 }
 
 export const FullScreenLoadingState = ({
-  withBackground = false,
+  overlay = false,
 }: FullScreenLoadingStateProps) => {
+  const isDarkTheme = useIsDarkTheme();
+  const backgroundOverlayStyle = isDarkTheme
+    ? styles.backgroundBlack
+    : styles.backgroundWhite;
   return (
-    <View style={[styles.container, withBackground && styles.background]}>
+    <View style={[styles.container, overlay && backgroundOverlayStyle]}>
       <ActivityIndicator size="large" />
     </View>
   );

--- a/apps/sample-app/src/hooks/useCreateAdaptiveTheme.ts
+++ b/apps/sample-app/src/hooks/useCreateAdaptiveTheme.ts
@@ -1,0 +1,29 @@
+import { useColorScheme } from 'react-native';
+
+import { MD3DarkTheme, MD3LightTheme, MD3Theme } from 'react-native-paper';
+
+export function useCreateAdaptiveTheme(): MD3Theme {
+  const isDark = useColorScheme() === 'dark';
+
+  return isDark
+    ? {
+        ...MD3DarkTheme,
+        colors: {
+          ...MD3DarkTheme.colors,
+          backdrop: '#424242',
+          background: '#121212',
+          onSurface: '#FFFFFF',
+          onBackground: '#EFEFEF',
+          primary: '#BB86FC',
+        },
+      }
+    : {
+        ...MD3LightTheme,
+        colors: {
+          ...MD3LightTheme.colors,
+          primary: '#BB86FC',
+        },
+      };
+}
+
+export default useCreateAdaptiveTheme;

--- a/apps/sample-app/src/hooks/useCreateAdaptiveTheme.ts
+++ b/apps/sample-app/src/hooks/useCreateAdaptiveTheme.ts
@@ -1,27 +1,46 @@
 import { useColorScheme } from 'react-native';
 
-import { MD3DarkTheme, MD3LightTheme, MD3Theme } from 'react-native-paper';
+import {
+  DarkTheme as NavigationDarkTheme,
+  DefaultTheme as NavigationDefaultTheme,
+} from '@react-navigation/native';
+import {
+  adaptNavigationTheme,
+  MD3DarkTheme,
+  MD3LightTheme,
+} from 'react-native-paper';
 
-export function useCreateAdaptiveTheme(): MD3Theme {
+export function useCreateAdaptiveTheme() {
   const isDark = useColorScheme() === 'dark';
+
+  const { LightTheme, DarkTheme } = adaptNavigationTheme({
+    reactNavigationLight: NavigationDefaultTheme,
+    reactNavigationDark: NavigationDarkTheme,
+  });
 
   return isDark
     ? {
         ...MD3DarkTheme,
+        ...DarkTheme,
         colors: {
           ...MD3DarkTheme.colors,
+          ...DarkTheme.colors,
           backdrop: '#424242',
           background: '#121212',
           onSurface: '#FFFFFF',
           onBackground: '#EFEFEF',
           primary: '#BB86FC',
+          onPrimary: '#FFFFFF',
         },
       }
     : {
         ...MD3LightTheme,
+        ...LightTheme,
         colors: {
           ...MD3LightTheme.colors,
+          ...LightTheme.colors,
           primary: '#BB86FC',
+          onPrimary: '#FFFFFF',
         },
       };
 }

--- a/apps/sample-app/src/hooks/useIsDarkTheme.ts
+++ b/apps/sample-app/src/hooks/useIsDarkTheme.ts
@@ -1,0 +1,7 @@
+import { useColorScheme } from 'react-native';
+
+export function useIsDarkTheme(): boolean {
+  return useColorScheme() === 'dark';
+}
+
+export default useIsDarkTheme;

--- a/apps/sample-app/src/navigation/RootNavigationContainer.tsx
+++ b/apps/sample-app/src/navigation/RootNavigationContainer.tsx
@@ -78,8 +78,9 @@ const RootStack = () => {
 };
 
 export const RootNavigationContainer = () => {
+  const theme = useCreateAdaptiveTheme();
   return (
-    <NavigationContainer>
+    <NavigationContainer theme={theme}>
       <RootStack />
     </NavigationContainer>
   );

--- a/apps/sample-app/src/navigation/RootNavigationContainer.tsx
+++ b/apps/sample-app/src/navigation/RootNavigationContainer.tsx
@@ -1,10 +1,11 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 
-import { DefaultTheme, NavigationContainer } from '@react-navigation/native';
+import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
 import { FullScreenLoadingState } from '@/components/fullScreenLoadingState/FullScreenLoadingState';
 import { useAuthContext } from '@/contexts/auth/AuthContext';
+import useCreateAdaptiveTheme from '@/hooks/useCreateAdaptiveTheme.ts';
 import { ContextMenu } from '@/navigation/contextMenu/ContexMenu';
 import { FileViewerScreen } from '@/screens/fileViewer/FileViewerScreen';
 import { LoginScreen } from '@/screens/login/LoginScreen';
@@ -15,14 +16,6 @@ export type RootStackParamList = {
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
-
-const MyTheme = {
-  ...DefaultTheme,
-  colors: {
-    ...DefaultTheme.colors,
-    background: 'white',
-  },
-};
 
 const headerRight = (folderId?: string) => <ContextMenu folderId={folderId} />;
 
@@ -36,6 +29,20 @@ const RootStack = () => {
     }
   }, [silentLogin, initializationStatus]);
 
+  const theme = useCreateAdaptiveTheme();
+
+  const screenOptions = useMemo(
+    () => ({
+      contentStyle: {
+        backgroundColor: theme.colors.background,
+      },
+      headerStyle: {
+        backgroundColor: theme.colors.primary,
+      },
+    }),
+    [theme.colors]
+  );
+
   if (
     initializationStatus === 'initializing' ||
     initializationStatus === 'idle'
@@ -44,18 +51,22 @@ const RootStack = () => {
   }
 
   return (
-    <Stack.Navigator>
+    <Stack.Navigator screenOptions={screenOptions}>
       {!authClient ? (
         <Stack.Screen
           name="Login"
           component={LoginScreen}
-          options={{ title: 'Sign in' }}
+          options={{
+            ...screenOptions,
+            title: 'Sign in',
+          }}
         />
       ) : (
         <Stack.Screen
           name="FileViewer"
           component={FileViewerScreen}
           options={({ route }) => ({
+            ...screenOptions,
             title: route.params.folderName || provider || 'File Viewer',
             headerRight: () => headerRight(route.params.folderId),
           })}
@@ -68,7 +79,7 @@ const RootStack = () => {
 
 export const RootNavigationContainer = () => {
   return (
-    <NavigationContainer theme={MyTheme}>
+    <NavigationContainer>
       <RootStack />
     </NavigationContainer>
   );

--- a/apps/sample-app/src/navigation/contextMenu/ContexMenu.tsx
+++ b/apps/sample-app/src/navigation/contextMenu/ContexMenu.tsx
@@ -12,6 +12,7 @@ import { useSnackbar } from '@/contexts/snackbar/SnackbarContent';
 import { useRequireStorageClient } from '@/contexts/storage/useRequireStorageClient';
 import { useUIContext } from '@/contexts/ui/UIContext';
 import { useLocalFileUploadMutation } from '@/data/mutation/useLocalFileUploadMutation';
+import useCreateAdaptiveTheme from '@/hooks/useCreateAdaptiveTheme.ts';
 
 import { styles } from './ContextMenu.styles';
 
@@ -32,6 +33,8 @@ export const ContextMenu = ({ folderId }: ContextMenuProps) => {
   );
   const bottomSheetRef = useRef<BottomSheetModal>(null);
   const [visible, setVisible] = useState(false);
+
+  const theme = useCreateAdaptiveTheme();
 
   const handleMenuOpen = () => setVisible(true);
 
@@ -77,7 +80,12 @@ export const ContextMenu = ({ folderId }: ContextMenuProps) => {
         visible={visible}
         onDismiss={handleMenuClose}
         anchor={
-          <IconButton icon="dots-vertical" size={24} onPress={handleMenuOpen} />
+          <IconButton
+            iconColor={theme.colors.onSurface}
+            icon="dots-vertical"
+            size={24}
+            onPress={handleMenuOpen}
+          />
         }
         style={styles.menu}
       >

--- a/apps/sample-app/src/navigation/contextMenu/ContexMenu.tsx
+++ b/apps/sample-app/src/navigation/contextMenu/ContexMenu.tsx
@@ -70,7 +70,7 @@ export const ContextMenu = ({ folderId }: ContextMenuProps) => {
   if (isPending) {
     return (
       <Portal>
-        <FullScreenLoadingState withBackground />
+        <FullScreenLoadingState overlay />
       </Portal>
     );
   }

--- a/apps/sample-app/src/screens/fileViewer/FileViewerScreen.styles.ts
+++ b/apps/sample-app/src/screens/fileViewer/FileViewerScreen.styles.ts
@@ -7,7 +7,4 @@ export const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
-  searchBar: {
-    backgroundColor: 'white',
-  },
 });

--- a/apps/sample-app/src/screens/fileViewer/FileViewerScreen.tsx
+++ b/apps/sample-app/src/screens/fileViewer/FileViewerScreen.tsx
@@ -99,7 +99,7 @@ export const FileViewerScreen = () => {
     if (downloadFileMutation.isPending) {
       return (
         <Portal>
-          <FullScreenLoadingState withBackground />
+          <FullScreenLoadingState overlay />
         </Portal>
       );
     }

--- a/apps/sample-app/src/screens/fileViewer/FileViewerScreen.tsx
+++ b/apps/sample-app/src/screens/fileViewer/FileViewerScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { FlatList, View } from 'react-native';
 
 import { File, StorageEntity } from '@openmobilehub/storage-core';
@@ -16,6 +16,7 @@ import { useRequireStorageClient } from '@/contexts/storage/useRequireStorageCli
 import { useDownloadFileMutation } from '@/data/mutation/useDownloadFileMutation';
 import { useFileListQuery } from '@/data/query/fileListQuery';
 import { useSearchFilesQuery } from '@/data/query/useSearchFilesQuery';
+import useCreateAdaptiveTheme from '@/hooks/useCreateAdaptiveTheme.ts';
 import { type RootStackParamList } from '@/navigation/RootNavigationContainer';
 
 import { styles } from './FileViewerScreen.styles';
@@ -78,6 +79,14 @@ export const FileViewerScreen = () => {
     }
   };
 
+  const theme = useCreateAdaptiveTheme();
+  const searchBarStyle = useMemo(
+    () => ({
+      backgroundColor: theme.colors.background,
+    }),
+    [theme.colors.background]
+  );
+
   const renderEmptyListComponent = useCallback(() => {
     if (fileListQuery.isLoading || searchFilesQuery.isLoading) {
       return <FullScreenLoadingState />;
@@ -106,7 +115,7 @@ export const FileViewerScreen = () => {
         <Searchbar
           placeholder="Search"
           onChangeText={setSearchQuery}
-          style={styles.searchBar}
+          style={searchBarStyle}
           value={searchQuery}
         />
         <Divider />


### PR DESCRIPTION
## Summary
Dark theme support - same color pallet as react-native-omh-maps and android-omh-storage

## Demo

https://github.com/user-attachments/assets/57c6935e-8d8a-4583-b5da-296b77e07863

https://github.com/user-attachments/assets/5f477d1e-a08b-4dcd-9ea2-3e1cd729d7a1


- [x] Documentation is up to date to reflect these changes

Closes: [OMHD-532](https://callstackio.atlassian.net/browse/OMHD-532)
