### PR TITLE
fix: apply headerTintColor

### DIFF
--- a/apps/sample-app/src/navigation/RootNavigationContainer.tsx
+++ b/apps/sample-app/src/navigation/RootNavigationContainer.tsx
@@ -39,6 +39,7 @@ const RootStack = () => {
       headerStyle: {
         backgroundColor: theme.colors.primary,
       },
+      headerTintColor: theme.colors.onSurface,
     }),
     [theme.colors]
   );


### PR DESCRIPTION
## Summary
A bug was introduced in #64 - a back button is invisible on iOS due to having the same color as the navigation header background.

## Dem

https://github.com/user-attachments/assets/6fdf33a3-5cdb-4609-a180-0eb80a0d4696


- [x] Documentation is up to date to reflect these changes

Closes: n/a
