### PR TITLE
fix/OMHD-558: Google Drive Update fixes

### DIFF
--- a/apps/sample-app/src/components/FileListItem/FileListItem.tsx
+++ b/apps/sample-app/src/components/FileListItem/FileListItem.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useRef } from 'react';
 import { Alert, Image } from 'react-native';
 
 import { BottomSheetModal } from '@gorhom/bottom-sheet';
@@ -52,22 +52,16 @@ export const FileListItem = ({ file, onPress }: Props) => {
     bottomSheetModalRef.current?.present();
   }, []);
 
-  const deleteHandlers = useMemo(() => {
-    return {
-      onSuccess: () => {
-        showSnackbar('File deleted');
-      },
-      onError: () => {
-        showSnackbar('Failed to delete file');
-      },
-    };
-  }, [showSnackbar]);
-
   const handleDeletePress = () => {
     deleteFileMutation.mutate(
       { fileId: file.id },
       {
-        ...deleteHandlers,
+        onSuccess: () => {
+          showSnackbar('File deleted');
+        },
+        onError: () => {
+          showSnackbar('Failed to delete file');
+        },
       }
     );
   };
@@ -85,7 +79,17 @@ export const FileListItem = ({ file, onPress }: Props) => {
           text: 'Delete',
           style: 'destructive',
           onPress: () => {
-            permanentDeleteFileMutation.mutate({ fileId: file.id });
+            permanentDeleteFileMutation.mutate(
+              { fileId: file.id },
+              {
+                onSuccess: () => {
+                  showSnackbar('File permanently deleted');
+                },
+                onError: () => {
+                  showSnackbar('Failed to permanently delete file');
+                },
+              }
+            );
           },
         },
       ]

--- a/apps/sample-app/src/components/bottomSheetContent/parts/bottomSheetOptions/BottomSheetOptions.tsx
+++ b/apps/sample-app/src/components/bottomSheetContent/parts/bottomSheetOptions/BottomSheetOptions.tsx
@@ -1,4 +1,4 @@
-import { File, StorageEntity } from '@openmobilehub/storage-core';
+import { File, Folder, StorageEntity } from '@openmobilehub/storage-core';
 import { Divider, Icon, Menu } from 'react-native-paper';
 
 import { Provider } from '@/constants/provider';
@@ -26,15 +26,27 @@ export const BottomSheetOptions = ({
   const { provider } = useAuthContext();
 
   const isFile = file instanceof File;
+  const isFolder = file instanceof Folder;
 
   const handleUpdatePress = () => {
     const isFolderUpdateSupported = provider === Provider.GOOGLEDRIVE;
 
-    if (isFile || isFolderUpdateSupported) {
-      setView(BottomSheetContentType.Update);
-    } else {
+    if (isFolder && !isFolderUpdateSupported) {
       showSnackbar('Updating folders is not supported by provider');
+      return;
     }
+
+    if (isFile) {
+      const isGoogleWorkspaceFile = file?.mimeType?.includes(
+        'application/vnd.google-apps'
+      );
+      if (isGoogleWorkspaceFile) {
+        showSnackbar('Updating Google Workspace files is not supported');
+        return;
+      }
+    }
+
+    setView(BottomSheetContentType.Update);
   };
 
   const leadingIcon = (props: any) => (

--- a/packages/googledrive/README.md
+++ b/packages/googledrive/README.md
@@ -93,7 +93,6 @@ The method `createPermission` will override `sendNotificationEmail` parameter to
 
 The method `updateFile` does not support [Google Workspace documents](https://developers.google.com/drive/api/guides/about-files#types:~:text=Google%20Workspace%20document,MIME%20types). It throws an error for Google Sheets and Slides and for Google Docs, it does not update the metadata (apart from file name) which can lead to unexpected behavior.
 
-
 :::
 
 ## License

--- a/packages/googledrive/README.md
+++ b/packages/googledrive/README.md
@@ -91,6 +91,9 @@ The methods `downloadFile` and `downloadFileVersion` do not support [Google Work
 
 The method `createPermission` will override `sendNotificationEmail` parameter to `true` when creating permission with `owner` role.
 
+The method `updateFile` does not support [Google Workspace documents](https://developers.google.com/drive/api/guides/about-files#types:~:text=Google%20Workspace%20document,MIME%20types). It throws an error for Google Sheets and Slides and for Google Docs, it does not update the metadata (apart from file name) which can lead to unexpected behavior.
+
+
 :::
 
 ## License


### PR DESCRIPTION
## Summary
This PR blocks Google Workspace files update in sample application as it might lead to unexpected behaviours. Additionally it adds a new caveat to the Google Drive documentation.

## Demo

iOS:

https://github.com/user-attachments/assets/e308308e-3d62-44af-bfd2-d27785afb83f

Android:

https://github.com/user-attachments/assets/3dbe1c86-d746-4537-b60a-eb584f04db80

- [x] Documentation is up to date to reflect these changes

Closes: [OMHD-558](https://callstackio.atlassian.net/browse/OMHD-558)
Closes: [OMHD-560](https://callstackio.atlassian.net/browse/OMHD-560)
Closes: [OMHD-561](https://callstackio.atlassian.net/browse/OMHD-561)
