### PR TITLE
fix: proper debugKeystorePath for both CI and local android builds

### DIFF
--- a/apps/sample-app/android/app/build.gradle
+++ b/apps/sample-app/android/app/build.gradle
@@ -115,7 +115,11 @@ android {
     }
     signingConfigs {
         debug {
-            storeFile file('debug.keystore')
+            def isCi = providers.environmentVariable("CI").getOrElse("false").toBoolean()
+            def debugKeystorePath = isCi
+            ? "${rootProject.projectDir}/debug.keystore"
+            : "${System.getenv('HOME')}/.android/debug.keystore"
+            storeFile file(debugKeystorePath)
             storePassword 'android'
             keyAlias 'androiddebugkey'
             keyPassword 'android'


### PR DESCRIPTION
## Summary

Detect if we're on CI or not and use proper `debugKeystorePath`.
If `isCi` is true we would search for keystore file from project directory otherwise we will use keystore from users root space. 


To test one can clone the repo and change fallback value for `isCi` check in `build.gradle` file.

Fixes #55 