### PR TITLE
fix/OMHD-536: Dropbox notification fix

### DIFF
--- a/packages/dropbox/src/DropboxStorageRepository.ts
+++ b/packages/dropbox/src/DropboxStorageRepository.ts
@@ -195,7 +195,7 @@ export class DropboxStorageRepository {
       custom_message: emailMessage,
       file: fileId,
       members: [mapPermissionRecipientToMemberSelector(recipient)],
-      quiet: sendNotificationEmail,
+      quiet: !sendNotificationEmail,
     };
 
     await this.apiService.addFileMember(body);
@@ -217,7 +217,7 @@ export class DropboxStorageRepository {
           member: mapPermissionRecipientToMemberSelector(recipient),
         },
       ],
-      quiet: sendNotificationEmail,
+      quiet: !sendNotificationEmail,
     };
 
     await this.apiService.addFolderMember(body);


### PR DESCRIPTION
## Summary

This PR fixes dropbox notifications by fixing the `quiet` flag.

## Demo

https://github.com/user-attachments/assets/8c8f7bf4-47c0-4c18-bdf2-9c5b291c8253

- [x] Documentation is up to date to reflect these changes

Closes: [OMHD-536](https://callstackio.atlassian.net/browse/OMHD-536)
